### PR TITLE
Add option for disable js loader and use native media attribute in link tag

### DIFF
--- a/playground/vite/main.ts
+++ b/playground/vite/main.ts
@@ -1,3 +1,1 @@
-import "./assets/style.css"
-
 document.getElementById("app")!.innerHTML = "__VITE-PLUGIN__"

--- a/src/functions/get-native-links.ts
+++ b/src/functions/get-native-links.ts
@@ -1,0 +1,11 @@
+import { MediaRecord } from "@/api";
+import { getLinkHref } from "./extract-media-data";
+
+export function getNativeLinksHtml(mediaData: MediaRecord[]): string
+{
+    return mediaData.map(record => buildLinkElement(record)).join("\n");
+}
+
+function buildLinkElement(record: MediaRecord): string {
+    return `<link rel="stylesheet" crossorigin media="${record.mediaQuery}" href="${getLinkHref(record.mediaQuery, record.filePath)}">`;
+}

--- a/src/integrations/vite-plugin.ts
+++ b/src/integrations/vite-plugin.ts
@@ -9,9 +9,11 @@ import { writeHTMLFiles } from "../functions/write-html-files"
 import { stringifyReport } from "../functions/report"
 
 import processCssMediaSplitter from "../process"
+import { getNativeLinksHtml } from "../functions/get-native-links"
 
 interface Options {
-  mediaFileMinSize?: number
+  mediaFileMinSize?: number,
+  useNativeLinkMedia?: boolean
 }
 
 export default function VitePluginCssMediaSplitter(options?: Options): Plugin {
@@ -44,7 +46,7 @@ export default function VitePluginCssMediaSplitter(options?: Options): Plugin {
 
         await writeHTMLFiles({
           files: htmlFiles,
-          html: result.loader.html,
+          html: options?.useNativeLinkMedia ? getNativeLinksHtml(result.mediaData) : result.loader.html,
         })
 
         // eslint-disable-next-line no-console

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 
-import type { MediaManifest } from "./models/Media"
+import type { MediaManifest, MediaRecord } from "./models/Media"
 import type { Loader } from "./models/Loader"
 import type { Report } from "./models/Report"
 
@@ -20,7 +20,8 @@ const DEFAULT_MEDIA_FILE_MIN_SIZE = 100
 export default async function processCssMediaSplitter(options: Options): Promise<null | {
   loader: Loader
   manifest: MediaManifest
-  report: Report
+  report: Report,
+  mediaData: MediaRecord[]
 }> {
   const distDir = path.resolve(options.distDir)
 
@@ -70,5 +71,6 @@ export default async function processCssMediaSplitter(options: Options): Promise
     loader,
     manifest: mediaManifest,
     report,
+    mediaData
   }
 }


### PR DESCRIPTION
Hello)  Thanks for this plugin.
I would like to be able to disable the "js loader" for styles. And use the native media attribute of the link tag instead.
To get something like this as a result:
`<link rel="stylesheet" media="screen and (min-width: 768px)" href="/768.css">`