### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/integrations/nuxt-module.ts
+++ b/src/integrations/nuxt-module.ts
@@ -33,7 +33,7 @@ export default defineNuxtModule<Options>({
     nuxt.options.features.inlineStyles = false
 
     const IS_GENERATE = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */
-    const IS_BUILD = !nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ && !nuxt.options._prepare && !nuxt.options._start && !nuxt.options.dev
+    const IS_BUILD = !IS_GENERATE && !nuxt.options._prepare && !nuxt.options._start && !nuxt.options.dev
 
     if (IS_GENERATE) {
       await nuxt.hook("close", async () => {

--- a/src/integrations/nuxt-module.ts
+++ b/src/integrations/nuxt-module.ts
@@ -32,8 +32,8 @@ export default defineNuxtModule<Options>({
     // Prevent style inlining
     nuxt.options.features.inlineStyles = false
 
-    const IS_GENERATE = nuxt.options._generate
-    const IS_BUILD = !nuxt.options._generate && !nuxt.options._prepare && !nuxt.options._start && !nuxt.options.dev
+    const IS_GENERATE = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */
+    const IS_BUILD = !nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ && !nuxt.options._prepare && !nuxt.options._start && !nuxt.options.dev
 
     if (IS_GENERATE) {
       await nuxt.hook("close", async () => {


### PR DESCRIPTION

Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.